### PR TITLE
Fix log statement of parameter type which are of an enum type

### DIFF
--- a/test/src/persist_parameter_client.cpp
+++ b/test/src/persist_parameter_client.cpp
@@ -107,7 +107,7 @@ bool PersistParametersClient::read_parameter(const std::string & param_name, std
         }
         default: {
           ret = false;
-          RCLCPP_INFO(this->get_logger(), "parameter %s unsupported type %s", param_name.c_str(), param.get_type());
+          RCLCPP_INFO(this->get_logger(), "parameter %s unsupported type %d", param_name.c_str(), param.get_type());
           break;
       }
     }


### PR DESCRIPTION
This fixes a compile error in Humble. Foxy still compiles fine after the fix.