### PR TITLE
perform periodic storing of the yaml file to avoid data loss in case the node is kiled unexpectedly.

### DIFF
--- a/server/include/parameter_server.h
+++ b/server/include/parameter_server.h
@@ -30,9 +30,10 @@ public:
   RCLCPP_SMART_PTR_DEFINITIONS(ParameterServer)
 
   ParameterServer(
-    const std::string& node_name,
+    const std::string & node_name,
     const rclcpp::NodeOptions & options,
-    const std::string& persistent_yaml_file);
+    const std::string & persistent_yaml_file,
+    unsigned int storing_period);
   ~ParameterServer();
 
 private:
@@ -69,6 +70,9 @@ private:
 
   // set parameters callback handler
   OnSetParametersCallbackHandle::SharedPtr callback_handler_;
+
+  // for periodic storing to the file system
+  rclcpp::TimerBase::SharedPtr timer_;
 };
 
 #endif // __PARAMETER_SERVER_H__

--- a/server/launch/parameter_server.launch.py
+++ b/server/launch/parameter_server.launch.py
@@ -25,18 +25,30 @@ parameters_file_name = 'parameters_via_launch.yaml'
 def generate_launch_description():
     parameters_file_path = str(pathlib.Path(__file__).parents[1]) # get current path and go one level up
     parameters_file_path += '/param/' + parameters_file_name
-    return LaunchDescription([
-        launch_ros.actions.Node(
-            package='parameter_server', executable='server', output='screen',
-            # respawn in 5.0 seconds
-            respawn = True, respawn_delay = 5.0,
-
-            # these parameters in parameters_file_path cannot be registered as persistent parameters,
-            # these will be loaded as normal parameter without event on /parameter_events topic.
-            parameters=[parameters_file_path],
-
-            # this example to load persistent parameter files into parameter server,
-            # these parameters descibed in parameter_server.yaml with prefix "persistent" will be registered as persistent parameter.
-            #arguments=['--file-path', '/tmp/parameter_server.yaml']
-        )
-    ])
+    return LaunchDescription(
+        [
+            launch_ros.actions.Node(
+                package="parameter_server",
+                executable="server",
+                output="screen",
+                # respawn in 5.0 seconds
+                respawn=True,
+                respawn_delay=5.0,
+                # these parameters in parameters_file_path cannot be registered as persistent parameters,
+                # these will be loaded as normal parameter without event on /parameter_events topic.
+                parameters=[parameters_file_path],
+                # this example to load persistent parameter files into parameter server,
+                # these parameters descibed in parameter_server.yaml with prefix "persistent" will be registered as persistent parameter.
+                # arguments=[
+                #     "--file-path",
+                #     "/tmp/parameter_server.yaml",
+                #     "--allow-declare",
+                #     "true",
+                #     "--allow-override",
+                #     "true",
+                #     "--storing-period",
+                #     "60",
+                # ],
+            )
+        ]
+    )

--- a/server/src/main.cpp
+++ b/server/src/main.cpp
@@ -39,7 +39,9 @@ int main(int argc, char **argv)
     ("allow-declare,d", value<bool>()->default_value(true),
     "enable(true) / disable(false) allow_undeclared_parameters via node option (default true)")
     ("allow-override,o", value<bool>()->default_value(true),
-    "enable(true) / disable(false) automatically_declare_parameters_from_overrides via node option (default true)");
+    "enable(true) / disable(false) automatically_declare_parameters_from_overrides via node option (default true)")
+    ("storing-period,s", value<unsigned int>()->default_value(60),
+    "period in seconds for periodic persistent parameter storing (default 60). No periodic storing is performed if this parameter is set to 0");
 
   variables_map vm;
   store(basic_command_line_parser<char>(nonros_args).options(description).run(), vm);
@@ -49,6 +51,7 @@ int main(int argc, char **argv)
   string opt_file("/tmp/parameter_server.yaml");
   bool opt_allow_declare = true;
   bool opt_allow_override = true;
+  unsigned int storing_period = 60;
 
   if (vm.count("help"))
   {
@@ -61,6 +64,7 @@ int main(int argc, char **argv)
     opt_file = vm["file-path"].as<string>();
     opt_allow_declare = vm["allow-declare"].as<bool>();
     opt_allow_override = vm["allow-override"].as<bool>();
+    storing_period = vm["storing-period"].as<unsigned int>();
   }
 
   rclcpp::NodeOptions options = (
@@ -72,7 +76,7 @@ int main(int argc, char **argv)
   ParameterServer::SharedPtr node = nullptr;
   try
   {
-    node = ParameterServer::make_shared(node_name, options, opt_file);
+    node = ParameterServer::make_shared(node_name, options, opt_file, storing_period);
     if (node == nullptr)
     {
       throw std::bad_alloc();
@@ -94,4 +98,3 @@ int main(int argc, char **argv)
   rclcpp::shutdown();
   return ret;
 }
-


### PR DESCRIPTION
This is useful to avoid data loss in case the node is killed by an unexpected signal. By a SIGKILL for instance.
- Added a `timer_` whose callback calls `StoreYamlFile()`. 
- Added the new option `storing_frequency` to let the user decides of the storing frequency. If its value is not > 0, then the timer is not armed.