### PR TITLE
Fix/dynamic typing

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,12 +76,14 @@ parameter server has the following scope for persistent parameter. since paramet
   Since ROS 2 parameter is owned by node, node name will be needed to access the parameters, this is designed to clarify semantics for the parameters and owners. Node name will be "parameter_server" if node name is not specifies. so the other nodes can use "parameter_server" as well to access in the same system Parameter Server. If there must exist multiple parameter servers, these parameter servers need to specify a different node name, such as "parameter_server_[special_string]", please notice that ROS 2 node name can only contains alphanumerics and '_'.
 - Persistent Volume
   Definition of "Persistent" is different from user and use cases, so it should be configurable to set the path to store the persistent --file-path FILE_PATH parameter. Expecting if the parameter's lifespan is system boot, path would be "/tmp" because user wants a fresh start via reboot. Or maybe physical persistent volume is chosen if users want to keep the parameter into the hardware storage. At the initialization time, Parameter Server will load the parameters from the storage which is specified by user.
+- Storing Period
+  By default, this option is enabled, allowing any parameter name to be set on the parameter server without prior declaration. If disabled, parameters must be explicitly declared before being set.
 - Node Options
-  there are two important options,
-  allow_undeclared_parameters: (default true)
-  automatically_declare_parameters_from_overrides: (default true)
-
-all of the configuration options will be passed via arguments as following.
+  there are three important options:
+  - allow_undeclared_parameters: (default true)
+  - automatically_declare_parameters_from_overrides: (default true)
+  - allow_dynamic_typing: (default false)
+all of the configuration options will be passed via arguments as followings.
 
 <table>
     <thead>
@@ -108,13 +110,24 @@ all of the configuration options will be passed via arguments as following.
             <td>in default, "/tmp/parameter_server.yaml" will be used. if specified, that path will be used to store/load the parameter yaml file.</td>
         </tr>
         <tr>
-            <td rowspan=2>Node Options</td>
+        <tr>
+            <td>Storing Period</td>
+            <td>--storing-period STORING_PERIOD</td>
+            <td>Specifies the interval (in seconds) for periodically storing persistent parameters to the file system. A value of 0 disables periodic storing.</td>
+        </tr>
+        </tr>
+        <tr>
+            <td rowspan=3>Node Options</td>
             <td>--allow-declare true/false</td>
             <td>default enabled, if specified allow any parameter name to be set on parameter server without declaration by itself. Otherwise it does not.</td>
         </tr>
         <tr>
             <td>--allow-override true/false</td>
             <td>default enabled, if specified true iterate through the node's parameter overrides or implicitly declare any that have not already been declared.</td>
+        </tr>
+        <tr>
+            <td>--allow-dynamic-typing true/false</td>
+            <td>Enables dynamic typing for parameters, allowing their types to be changed after declaration.</td>
         </tr>
     </tbody>
 </table>

--- a/README.md
+++ b/README.md
@@ -244,6 +244,7 @@ These samples verify the following functions.
 - persistent parameter can be read/modified from parameter client.
 - non-persistent parameter cannot be read/stored to/from the file system.
 - non-persistent parameter can be read/modified from parameter client
+- parameter type can be changed dynamically only when allow-dynamic-typing is set
 
 make sure to add the path of `launch` package to the PATH environment.
 
@@ -284,6 +285,19 @@ All of the test is listed with result as following
 [ros2-2] [INFO] [1601447662.145969623] [client]: h. Test Persistent Parameter Stores To File                  :             PASS
 [ros2-2] [INFO] [1601447662.145990707] [client]: i. Test New Added Normal Parameter Not Stores To File        :             PASS
 [ros2-2] [INFO] [1601447662.146011312] [client]: j. Test New Added Persistent Parameter Stores To File        :             PASS
+
+Test with default options finished. Proceeding to testing with node options
+......   // omit some output logs
+[INFO] [1751375380.682839476] [client]: ***************************************************************************
+[INFO] [1751375380.682849383] [client]: *********************************Test Result*******************************
+[INFO] [1751375380.682881950] [client]: a. dynamically change the type of an existing parameter      :             PASS
+[INFO] [1751375380.682896493] [client]: b. revert the type of the parameter to int                   :             PASS
+[INFO] [1751375380.682901049] [client]: c. create new parameter with type double                     :             PASS
+[INFO] [1751375380.682905050] [client]: d. change the type of the new parameter to string            :             PASS
+......   // omit some output logs
+Test process finished.
+Return Code: 0
+The process completed successfully.
 ```
 
 ## Known Issues

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ parameter server has the following scope for persistent parameter. since paramet
   - allow_undeclared_parameters: (default true)
   - automatically_declare_parameters_from_overrides: (default true)
   - allow_dynamic_typing: (default false)
-all of the configuration options will be passed via arguments as followings.
+all of the configuration options will be passed via arguments as following.
 
 <table>
     <thead>

--- a/server/include/parameter_server.h
+++ b/server/include/parameter_server.h
@@ -73,6 +73,8 @@ private:
 
   // for periodic storing to the file system
   rclcpp::TimerBase::SharedPtr timer_;
+
+  bool allow_dynamic_typing_ = false;
 };
 
 #endif // __PARAMETER_SERVER_H__

--- a/server/include/parameter_server.h
+++ b/server/include/parameter_server.h
@@ -32,8 +32,7 @@ public:
   ParameterServer(
     const std::string & node_name,
     const rclcpp::NodeOptions & options,
-    const std::string & persistent_yaml_file,
-    unsigned int storing_period);
+    const std::string & persistent_yaml_file);
   ~ParameterServer();
 
 private:

--- a/server/launch/parameter_server.launch.py
+++ b/server/launch/parameter_server.launch.py
@@ -37,7 +37,7 @@ def generate_launch_description():
                 # these parameters in parameters_file_path cannot be registered as persistent parameters,
                 # these will be loaded as normal parameter without event on /parameter_events topic.
                 parameters=[parameters_file_path],
-                # this example to load persistent parameter files into parameter server,
+                # this is an example to load persistent parameter files into parameter server,
                 # these parameters described in parameter_server.yaml with prefix "persistent" will be registered as persistent parameter.
                 # arguments=[
                 #     "--file-path",

--- a/server/launch/parameter_server.launch.py
+++ b/server/launch/parameter_server.launch.py
@@ -48,6 +48,8 @@ def generate_launch_description():
                 #     "true",
                 #     "--storing-period",
                 #     "60",
+                #     "--allow-dynamic-typing",
+                #     "true",
                 # ],
             )
         ]

--- a/server/src/main.cpp
+++ b/server/src/main.cpp
@@ -41,7 +41,9 @@ int main(int argc, char **argv)
     ("allow-override,o", value<bool>()->default_value(true),
     "enable(true) / disable(false) automatically_declare_parameters_from_overrides via node option (default true)")
     ("storing-period,s", value<unsigned int>()->default_value(60),
-    "period in seconds for periodic persistent parameter storing (default 60). No periodic storing is performed if this parameter is set to 0");
+    "period in seconds for periodic persistent parameter storing (default 60). No periodic storing is performed if this parameter is set to 0")
+    ("allow-dynamic-typing,t", value<bool>()->default_value(false),
+    "When enabled (true), allows parameter type to change upon reading from persistence. Disabled (false) by default");
 
   variables_map vm;
   store(basic_command_line_parser<char>(nonros_args).options(description).run(), vm);
@@ -52,6 +54,7 @@ int main(int argc, char **argv)
   bool opt_allow_declare = true;
   bool opt_allow_override = true;
   unsigned int storing_period = 60;
+  bool opt_allow_dynamic_typing = false;
 
   if (vm.count("help"))
   {
@@ -65,12 +68,14 @@ int main(int argc, char **argv)
     opt_allow_declare = vm["allow-declare"].as<bool>();
     opt_allow_override = vm["allow-override"].as<bool>();
     storing_period = vm["storing-period"].as<unsigned int>();
+    opt_allow_dynamic_typing = vm["allow-dynamic-typing"].as<bool>();
   }
 
   rclcpp::NodeOptions options = (
     rclcpp::NodeOptions()
     .allow_undeclared_parameters(opt_allow_declare)
     .automatically_declare_parameters_from_overrides(opt_allow_override)
+    .append_parameter_override("allow_dynamic_typing", opt_allow_dynamic_typing)
     );
 
   ParameterServer::SharedPtr node = nullptr;

--- a/server/src/main.cpp
+++ b/server/src/main.cpp
@@ -76,12 +76,13 @@ int main(int argc, char **argv)
     .allow_undeclared_parameters(opt_allow_declare)
     .automatically_declare_parameters_from_overrides(opt_allow_override)
     .append_parameter_override("allow_dynamic_typing", opt_allow_dynamic_typing)
+    .append_parameter_override("storing_period", static_cast<int>(storing_period))
     );
 
   ParameterServer::SharedPtr node = nullptr;
   try
   {
-    node = ParameterServer::make_shared(node_name, options, opt_file, storing_period);
+    node = ParameterServer::make_shared(node_name, options, opt_file);
     if (node == nullptr)
     {
       throw std::bad_alloc();

--- a/server/src/parameter_server.cpp
+++ b/server/src/parameter_server.cpp
@@ -213,10 +213,9 @@ void ParameterServer::LoadYamlFile()
         {
           // declare parameter
           RCLCPP_DEBUG(this->get_logger(), "declare %s %s", name.c_str(), to_string(value).c_str());
-          node_parameters->declare_parameter(
-            name,
-            value,
-            rcl_interfaces::msg::ParameterDescriptor());
+          rcl_interfaces::msg::ParameterDescriptor descriptor;
+          descriptor.dynamic_typing = true;
+          node_parameters->declare_parameter(name, value, descriptor);
 
           // 1. if automatically_declare_parameters_from_overrides is false,
           // parameter from __params: not declared but saved in overrides list,

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -29,24 +29,43 @@ find_package(rcutils REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(rmw REQUIRED)
 
-add_executable(client
-  src/test.cpp
+add_executable(client_default
+  src/test_default.cpp
   src/persist_parameter_client.cpp
 )
 
-target_link_libraries(client
+target_link_libraries(client_default
   rclcpp::rclcpp
   rclcpp_components::component
   rcutils::rcutils
   ${std_msgs_TARGETS}
 )
 
-target_include_directories(client
+target_include_directories(client_default
   PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
 )
 
-install(TARGETS client DESTINATION lib/${PROJECT_NAME})
+ament_target_dependencies(client_default rclcpp rclcpp_components std_msgs rcutils)
+
+add_executable(client_with_node_options
+  src/test_with_node_options.cpp
+  src/persist_parameter_client.cpp
+)
+
+target_link_libraries(client_with_node_options
+  rclcpp::rclcpp
+  rcutils::rcutils
+)
+
+target_include_directories(client_with_node_options
+  PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+)
+
+ament_target_dependencies(client_with_node_options rclcpp rclcpp_components std_msgs rcutils)
+
+install(TARGETS client_default client_with_node_options DESTINATION lib/${PROJECT_NAME})
 
 # Install launch files.
 install(DIRECTORY

--- a/test/include/test_common.h
+++ b/test/include/test_common.h
@@ -1,0 +1,201 @@
+// Copyright 2020 Sony Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef __TEST_COMMON_H__
+#define __TEST_COMMON_H__
+
+#include <map>
+#include <optional>
+#include <stdexcept>
+#include <type_traits>
+
+#include "persist_parameter_client.hpp"
+
+/**
+ * NoServerError
+ *
+ * The client will wait 5 seconds for the server to be ready.
+ * If timeout, then throw an exception to terminate the endless waiting.
+ */
+struct NoServerError : public std::runtime_error
+{
+public:
+  NoServerError() : std::runtime_error("cannot connect to server") {}
+};
+
+/*
+ * SetOperationError
+ *
+ * When executing `set_parameter`, if the set operation failed,
+ * throw an exception to ignore the subsequent test.
+ */
+struct SetOperationError : public std::runtime_error
+{
+public:
+  SetOperationError() : std::runtime_error("set operation failed") {}
+};
+
+class TestPersistParameter
+{
+public:
+  TestPersistParameter(const std::string & node_name, const rclcpp::NodeOptions & options)
+  : persist_param_client_(node_name, options)
+  {
+    if (!wait_param_server_ready()) {
+      throw NoServerError();
+    }
+  }
+
+  inline bool wait_param_server_ready() { return persist_param_client_.wait_param_server_ready(); }
+
+  /*
+    * Read the value of parameter.
+    * @param param_name The name of parameter.
+    * @param expected_value The value of the parameter that you expected, take std::string as example here.
+    * If `expected_value` is `nullopt`, it means the parameter is expected not to exist.
+    * @param testcase The test case description.
+    */
+  template <typename ValueType>
+  void do_read_and_check(
+    const std::string & param_name, const std::optional<ValueType> & expected_value,
+    const std::string & testcase)
+  {
+    bool value_matches = false;
+    std::vector<rclcpp::Parameter> parameter;
+
+    if (persist_param_client_.read_parameter(param_name, parameter)) {
+      for (auto & param : parameter) {
+        if (!expected_value.has_value()) {
+          if (param.get_type() == rclcpp::ParameterType::PARAMETER_NOT_SET) {
+            value_matches = true;
+            break;
+          }
+        } else {
+          switch (param.get_type()) {
+            case rclcpp::ParameterType::PARAMETER_STRING:
+              if constexpr (std::is_same_v<ValueType, std::string>) {
+                if (param.as_string() == expected_value.value()) {
+                  value_matches = true;
+                }
+              }
+              break;
+            case rclcpp::ParameterType::PARAMETER_INTEGER:
+              if constexpr (std::is_integral_v<ValueType>) {
+                if (param.as_int() == expected_value.value()) {
+                  value_matches = true;
+                }
+              }
+              break;
+            case rclcpp::ParameterType::PARAMETER_DOUBLE:
+              if constexpr (std::is_floating_point_v<ValueType>) {
+                if (
+                  abs(param.as_double() - expected_value.value()) <
+                  std::numeric_limits<double>::epsilon()) {
+                  value_matches = true;
+                }
+              }
+              break;
+            // One might extend here for other types if needed (e.g., bool, double)
+            default:
+              break;
+          }
+        }
+      }
+    }
+
+    /*
+       * Even if the Get operation failed, record it in result_map, and it shouldn't effect the
+       * subsequent tests.
+       */
+    this->set_result(testcase, value_matches);
+  }
+
+  /*
+    * Change the value of parameter.
+    * @param param_name The name of parameter.
+    * @param changed_value The value that you want to set.
+    * @param testcase The test case description.
+    */
+  template <typename ValueType>
+  void do_change_and_check(
+    const std::string & param_name, const ValueType & changed_value, const std::string & testcase)
+  {
+    bool ret = persist_param_client_.modify_parameter<ValueType>(param_name, changed_value);
+    /*
+       * If the Modify operation failed, record it in result_map, and no need to run the
+       * subsequent read tests.
+       */
+    if (!ret) {
+      this->set_result(testcase, false);
+      throw SetOperationError();
+    }
+
+    do_read_and_check(param_name, std::make_optional(changed_value), testcase);
+  }
+
+  template <typename ValueType>
+  void do_fail_to_change(
+    const std::string & param_name, const ValueType & attempted_value, const std::string & testcase)
+  {
+    bool ret = persist_param_client_.modify_parameter<ValueType>(param_name, attempted_value);
+
+    // this must fail. So set result to true if ret is false
+    this->set_result(testcase, !ret);
+  }
+
+  // Get all test results.
+  inline int print_result() const
+  {
+    int ret = EXIT_SUCCESS;
+    RCLCPP_INFO(
+      this->get_logger(),
+      "****************************************************"
+      "***********************");
+    RCLCPP_INFO(
+      this->get_logger(),
+      "*********************************Test Result*********"
+      "**********************");
+    for (const auto & res : result_map_) {
+      RCLCPP_INFO(
+        this->get_logger(), "%-60s : %16s", res.first.c_str(), res.second ? "PASS" : "NOT PASS");
+
+      // if any tests are not passed, return EXIT_FAILURE.
+      if (res.second == false) {
+        ret = EXIT_FAILURE;
+      }
+    }
+
+    return ret;
+  }
+
+  static inline rclcpp::Logger get_logger() { return client_logger_; }
+
+private:
+  // Save the result of each test operation.
+  inline void set_result(const std::string & key, bool value)
+  {
+    auto pair = result_map_.insert({key, value});
+    if (!pair.second) {
+      RCLCPP_INFO(this->get_logger(), "Failed when insert %s to result_map", key.c_str());
+    }
+
+    return;
+  }
+
+  PersistParametersClient persist_param_client_;
+  std::map<std::string, bool> result_map_;
+  static rclcpp::Logger client_logger_;
+};
+
+#endif

--- a/test/launch/test.launch.py
+++ b/test/launch/test.launch.py
@@ -16,12 +16,24 @@
 
 from launch import LaunchDescription
 from launch.substitutions import EnvironmentVariable
-import launch
+from launch.actions import ExecuteProcess, DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
+
 
 def generate_launch_description():
+    allow_dynamic_typing_arg = DeclareLaunchArgument(
+        'allow_dynamic_typing', default_value='false', description='Enable dynamic typing for parameters'
+    )
+
     return LaunchDescription([
-        launch.actions.ExecuteProcess(
-            cmd = ['ros2', 'run', 'parameter_server', 'server', '--file-path', '/tmp/test/parameter_server.yaml'],
+        allow_dynamic_typing_arg,
+        ExecuteProcess(
+            cmd=[
+                'ros2', 'run', 'parameter_server', 'server',
+                '--file-path', '/tmp/test/parameter_server.yaml',
+                '--allow-dynamic-typing', LaunchConfiguration(
+                    'allow_dynamic_typing')
+            ],
             respawn=True
         )
     ])

--- a/test/src/test_default.cpp
+++ b/test/src/test_default.cpp
@@ -1,0 +1,125 @@
+// Copyright 2020 Sony Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <map>
+#include <optional>
+#include <stdexcept>
+#include <type_traits>
+
+#include "persist_parameter_client.hpp"
+#include "test_common.h"
+
+rclcpp::Logger TestPersistParameter::client_logger_ = rclcpp::get_logger("client");
+
+int main(int argc, char ** argv)
+{
+  // force flush of the stdout buffer.
+  // this ensures a correct sync of all prints
+  // even when executed simultaneously within the launch file.
+  setvbuf(stdout, NULL, _IONBF, BUFSIZ);
+
+  rclcpp::init(argc, argv);
+  std::shared_ptr<TestPersistParameter> test_client;
+
+  int ret_code = 0;
+  // In case of an exception is thrown when performing an operation after `ctrl-c` occured.
+  try {
+    test_client = std::make_shared<TestPersistParameter>("client", rclcpp::NodeOptions());
+    /*
+    * First read parameter(include normal parameter and persistent parameter), to confirm the initial value of parameters.
+    * Parameter server is launched with file `/tmp/parameter_server.yaml`, in this file, parameter `a_string` is defined
+    * and the initial value is `Hello world`.
+    *
+    * Test: The default parameter `a_string` specified in YAML file which is loaded while parameter server is launched
+    * should be read correctly.
+    */
+    {
+      // If return fail, no need to do the following.
+      RCLCPP_INFO(test_client->get_logger(), "First read the initial value of parameter : ");
+      test_client->do_read_and_check<std::string>(
+        "a_string", "Hello world", "a. Read Normal Parameter");
+      test_client->do_read_and_check<std::string>(
+        "persistent.a_string", "Hello world", "b. Read Persistent Parameter");
+    }
+
+    /*
+    * Test: Modifying the parameter `a_string`'s value to `Hello`, and add a new parameter `new_string` to YAML file.
+    */
+    {
+      RCLCPP_INFO(test_client->get_logger(), "Change the value of parameter to `Hello` : ");
+      test_client->do_change_and_check<std::string>(
+        "a_string", std::string{"Hello"}, "c. Modify Existed Normal parameter");
+      test_client->do_change_and_check<std::string>(
+        "persistent.a_string", std::string{"Hello"}, "d. Modify Existed Persistent parameter");
+      RCLCPP_INFO(test_client->get_logger(), "Add a new parameter to parameter file : ");
+      test_client->do_change_and_check<std::string>(
+        "new_string", std::string{"Hello NewString"}, "e. Add New Normal parameter");
+      test_client->do_change_and_check<std::string>(
+        "persistent.new_string", std::string{"Hello NewString"}, "f. Add New Persistent parameter");
+    }
+
+    // Waiting for the server to restart.
+    std::this_thread::sleep_for(std::chrono::seconds(5));
+
+    /*
+    * Test : Reading parameter value again to confirm whether to store the modified persistent/normal parameter to the file.
+    */
+    {
+      if (!test_client->wait_param_server_ready()) {
+        throw NoServerError();
+      }
+      RCLCPP_INFO(
+        test_client->get_logger(),
+        "Last read the value of parameter after server restarts,"
+        "to check whether changes stores to the file : ");
+      test_client->do_read_and_check<std::string>(
+        "a_string", "Hello world", "g. Test Normal Parameter Not Stores To File");
+      test_client->do_read_and_check<std::string>(
+        "persistent.a_string", "Hello", "h. Test Persistent Parameter Stores To File");
+      test_client->do_read_and_check<std::string>(
+        "new_string", std::nullopt, "i. Test New Added Normal Parameter Not Stores To File");
+      test_client->do_read_and_check<std::string>(
+        "persistent.new_string", "Hello NewString",
+        "j. Test New Added Persistent Parameter Stores To File");
+    }
+
+    /*
+    * Test : Impossible to change the type of a parameter.
+    */
+    {
+      RCLCPP_INFO(
+        test_client->get_logger(), "Try to change the type of a parameter, must not be possible:");
+      test_client->do_fail_to_change<int>(
+        "persistent.a_string", 10, "k. Test could not change the type of persistent parameter");
+      test_client->do_fail_to_change<std::string>(
+        "some_int", "Not possible", "l. Test could not change the type of parameter");
+    }
+
+  } catch (const rclcpp::exceptions::RCLError & e) {
+    ret_code = -1;
+    RCLCPP_ERROR(test_client->get_logger(), "unexpectedly failed: %s", e.what());
+  } catch (const NoServerError & e) {
+    ret_code = -2;
+    RCLCPP_ERROR(test_client->get_logger(), "unexpectedly failed: %s", e.what());
+  } catch (const SetOperationError & e) {
+    ret_code = -3;
+    RCLCPP_ERROR(test_client->get_logger(), "unexpectedly failed: %s", e.what());
+  }
+
+  // if any tests are not passed, return EXIT_FAILURE.
+  ret_code = test_client->print_result();
+  rclcpp::shutdown();
+
+  return ret_code;
+}

--- a/test/src/test_default.cpp
+++ b/test/src/test_default.cpp
@@ -33,7 +33,7 @@ int main(int argc, char ** argv)
   std::shared_ptr<TestPersistParameter> test_client;
 
   int ret_code = 0;
-  // In case of an exception is thrown when performing an operation after `ctrl-c` occured.
+  // In case of an exception is thrown when performing an operation after `ctrl-c` occurred.
   try {
     test_client = std::make_shared<TestPersistParameter>("client", rclcpp::NodeOptions());
     /*

--- a/test/src/test_with_node_options.cpp
+++ b/test/src/test_with_node_options.cpp
@@ -1,0 +1,74 @@
+// Copyright 2020 Sony Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <map>
+#include <optional>
+#include <stdexcept>
+#include <type_traits>
+
+#include "persist_parameter_client.hpp"
+#include "test_common.h"
+
+rclcpp::Logger TestPersistParameter::client_logger_ = rclcpp::get_logger("client");
+
+// this test must be run somultaneously with the server node launched with the option allow-dynamic-typing set to true
+int main(int argc, char ** argv)
+{
+  // force flush of the stdout buffer.
+  // this ensures a correct sync of all prints
+  // even when executed simultaneously within the launch file.
+  setvbuf(stdout, NULL, _IONBF, BUFSIZ);
+
+  rclcpp::init(argc, argv);
+  std::shared_ptr<TestPersistParameter> test_client;
+
+  RCLCPP_INFO(test_client->get_logger(), "****************************************************"
+                                    "***********************");
+  int ret_code = 0;
+  try {
+    test_client = std::make_shared<TestPersistParameter>("client", rclcpp::NodeOptions());
+    /*
+    * Dynamic Typing Tests
+    *
+    * These tests will try to change the type of a parameter to see whether the
+    * server accepts it based on allow_dynamic_typing=true/false.
+    */
+    {
+      test_client->do_change_and_check<std::string>(
+        "persistent.some_int", "mutated", "a. dynamically change the type of an existing parameter");
+      test_client->do_change_and_check<int>(
+        "persistent.some_int", 10, "b. revert the type of the parameter to int");
+      test_client->do_change_and_check<double>(
+        "persistent.new_double", 3.14, "c. create new parameter with type double");
+      test_client->do_change_and_check<std::string>(
+        "persistent.new_double", "3.14", "d. change the type of the new parameter to string");
+    }
+
+  } catch (const rclcpp::exceptions::RCLError & e) {
+    ret_code = -1;
+    RCLCPP_ERROR(test_client->get_logger(), "unexpectedly failed: %s", e.what());
+  } catch (const NoServerError & e) {
+    ret_code = -2;
+    RCLCPP_ERROR(test_client->get_logger(), "unexpectedly failed: %s", e.what());
+  } catch (const SetOperationError & e) {
+    ret_code = -3;
+    RCLCPP_ERROR(test_client->get_logger(), "unexpectedly failed: %s", e.what());
+  }
+
+  // if any tests are not passed, return EXIT_FAILURE.
+  ret_code = test_client->print_result();
+  rclcpp::shutdown();
+
+  return ret_code;
+}

--- a/test/test.py
+++ b/test/test.py
@@ -75,14 +75,14 @@ client_process = subprocess.Popen(launchClientCmdWithNodeOptions)
 print(f"Parameter Client Process started with PID: {client_process.pid}")
 
 # Wait until the client process finishes and then kill the server
-return_code = client_process.wait()
+return_code2 = client_process.wait()
 os.killpg(os.getpgid(server_process.pid), signal.SIGTERM)
 
 print("\nTest process finished.")
 print(f"Return Code: {return_code}")
 
 # Check if the client process completed successfully
-if return_code == 0:
+if return_code == return_code2 == 0:
     print("The process completed successfully.")
     sys.exit(0)
 else:


### PR DESCRIPTION
When a parameter is loaded from yaml, its type cannot be changed latter through a call to set_parameters service. This is problematic in some cases. 
Here is a way to reproduce an issue related to this behavior:
- Launch parameter server
- Call the service `/parameter_server/set_parameters` to set a param `foo` with `PARAMETER_DOUBLE` type and a value of 1.0. Check the result of the service call (`successful` is `true`)
- Kill parameter server so the parameter is written to persistence
- Launch parameter server again
- Call the service `/parameter_server/set_parameters` to set a param `foo` with `PARAMETER_DOUBLE` type and a value of 1.0. Check the result of the service call (`successful` is `false`)
The reason is that `rcl_yaml_param_parser` reads 1.0 as an Integer.

The solution is to set `descriptor.dynamic_typing` to true while declaring the read parameters.

Note that this issue is observed only with parameters loaded from yaml. It is not noticed when setting a new parameter through service call (or command line client set) because in this case, the `descriptor.dynamic_typing` is set to true as in[ node_parameters](https://github.com/ros2/rclcpp/blob/7aff0ffc56b8875ceb7af6e5beb832721fffed19/rclcpp/src/rclcpp/node_interfaces/node_parameters.cpp#L235)