### PR TITLE
Added ros2 service call to manually trigger yaml save

### DIFF
--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -27,6 +27,7 @@ find_package(rclcpp REQUIRED)
 find_package(rclcpp_components REQUIRED)
 find_package(rcutils REQUIRED)
 find_package(std_msgs REQUIRED)
+find_package(std_srvs REQUIRED)
 find_package(rmw REQUIRED)
 
 find_package(Boost REQUIRED COMPONENTS program_options filesystem)
@@ -65,7 +66,7 @@ target_include_directories(server
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
 )
 
-ament_target_dependencies(server rclcpp rclcpp_components std_msgs rcutils)
+ament_target_dependencies(server rclcpp rclcpp_components std_msgs std_srvs rcutils)
 
 install(TARGETS server DESTINATION lib/${PROJECT_NAME})
 

--- a/server/include/parameter_server.h
+++ b/server/include/parameter_server.h
@@ -21,6 +21,7 @@
 #include <atomic>
 
 #include "rclcpp/rclcpp.hpp"
+#include "std_srvs/srv/trigger.hpp"
 #include "rclcpp_components/register_node_macro.hpp"
 #include "yaml-cpp/yaml.h"
 
@@ -73,6 +74,9 @@ private:
 
   // for periodic storing to the file system
   rclcpp::TimerBase::SharedPtr timer_;
+
+  // For manual triggering of save
+  rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr save_trigger_;
 };
 
 #endif // __PARAMETER_SERVER_H__

--- a/server/package.xml
+++ b/server/package.xml
@@ -18,6 +18,7 @@
   <depend>rmw</depend>
   <depend>rmw_implementation_cmake</depend>
   <depend>std_msgs</depend>
+  <depend>std_srvs</depend>
   <depend>yaml_cpp_vendor</depend>
 
   <exec_depend>launch_ros</exec_depend>

--- a/server/src/parameter_server.cpp
+++ b/server/src/parameter_server.cpp
@@ -73,6 +73,15 @@ ParameterServer::ParameterServer(
   // callback_handler_ needs to be alive to keep the callback functional
   callback_handler_ = this->add_on_set_parameters_callback(param_change_callback);
 
+  save_trigger_ = this->create_service<std_srvs::srv::Trigger>("~/save_params",
+    [this]([[maybe_unused]] const std_srvs::srv::Trigger::Request::SharedPtr& req,
+      [[maybe_unused]] const std_srvs::srv::Trigger::Response::SharedPtr& res
+    ) {
+      RCLCPP_INFO(this->get_logger(), "Parameter save manually requested");
+      this->StoreYamlFile();
+      res->success = true;
+  });
+
   LoadYamlFile();
 }
 


### PR DESCRIPTION
This PR is a follow up to #36 to allow a node to manually request that the parameters be saved to disk.  
Useful in case a particularly important param is saved that we don't want to risk waiting for the periodic save.  