### PR TITLE
declare dependencies to boost dev libraries

### DIFF
--- a/server/package.xml
+++ b/server/package.xml
@@ -12,6 +12,10 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <build_depend>libboost-dev</build_depend>
+  <build_depend>libboost-filesystem-dev</build_depend>
+  <build_depend>libboost-program-options-dev</build_depend>
+
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>rcutils</depend>


### PR DESCRIPTION
I had issue building this package on our buildfarm because Boost wasn't imported.

Note: I've only declared the dev dependencies and not the runtime dependencies because:
1) With dpkg packages at least they will be automatically detected.
2) `libboost-program-options` is not resolved on Debian Bookworm, thus preventing a release on Jazzy (see [this issue](https://github.com/ros/rosdistro/issues/47101) for reference).