### PR TITLE
Remove version info in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.5)
-project(persist_parameter_server VERSION 1.0.1)
+project(persist_parameter_server)
 
 # Set Release build if no build type was specified
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)


### PR DESCRIPTION
Now we are adding this project to rosdistro.   
Version updates are handled through the script `catkin_prepare_release`. It will only update the version in both CHANGELOG.rst and package.xml (No CMakeLists.txt). So I remove version info in CMakeLists.txt.  