### PR TITLE
doc,fix: link in readme pointing to valid URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ apt install libyaml-cpp-dev libboost-program-options-dev libboost-filesystem-dev
 
 ### Prerequisites
 
-[ROS 2 source build environment](https://index.ros.org/doc/ros2/Installation/Rolling/Linux-Development-Setup) is required to build and run the parameter server.
+[ROS 2 source build environment](http://docs.ros.org/en/rolling/Installation/Alternatives/Ubuntu-Development-Setup.html) is required to build and run the parameter server.
 
 ### Build
 


### PR DESCRIPTION
The URL to how to install ROS 2 has changed a while back.