### PR TITLE
fix redundant and unexpected mergify configuration for barckports.

### DIFF
--- a/.mergify/config.yml
+++ b/.mergify/config.yml
@@ -2,25 +2,14 @@ pull_request_rules:
   - name: automatic backport to all supported distribution
     description: |
       This rule backports a PR to all supported distribution branches when it is merged.
+      If any individual backport label is set, this rule is suppressed and label-based rules take over.
     conditions:
       - base=rolling
       - merged
-      - label!=skip-backport  # Do not backport if this label exists
-    actions:
-      backport:
-        branches:
-          - kilted
-          - jazzy
-          - humble
-
-  - name: backport at reviewers discretion
-    description: |
-      This rule backports a PR to all supported distribution branches when it is labeled.
-    conditions:
-      - base=rolling
-      - "label=backport-all"
-      - merged
-      - label!=skip-backport  # Do not backport if this label exists
+      - label!=skip-backport    # Do not backport if this label exists
+      - label!=backport-kilted  # Suppress auto-backport if reviewer controls it
+      - label!=backport-jazzy   # Suppress auto-backport if reviewer controls it
+      - label!=backport-humble  # Suppress auto-backport if reviewer controls it
     actions:
       backport:
         branches:


### PR DESCRIPTION
see https://github.com/fujitatomoya/ros2_persist_parameter_server/pull/73#issuecomment-4159469717