### PR TITLE
Add ROS Humble compatibility for parameter callbacks

### DIFF
--- a/server/include/parameter_server.h
+++ b/server/include/parameter_server.h
@@ -72,7 +72,10 @@ private:
 
   // set parameters callback handler
   OnSetParametersCallbackHandle::SharedPtr callback_handler_;
+#if RCLCPP_VERSION_MAJOR >= 17
+  // PostSetParametersCallback is available in Iron (rclcpp 17.x) and later
   PostSetParametersCallbackHandle::SharedPtr post_set_callback_handler_;
+#endif
 
   // for periodic storing to the file system
   rclcpp::TimerBase::SharedPtr timer_;

--- a/server/include/parameter_server.h
+++ b/server/include/parameter_server.h
@@ -21,6 +21,7 @@
 #include <atomic>
 
 #include "rclcpp/rclcpp.hpp"
+#include "rclcpp/version.h"
 #include "std_srvs/srv/trigger.hpp"
 #include "rclcpp_components/register_node_macro.hpp"
 #include "yaml-cpp/yaml.h"

--- a/server/src/parameter_server.cpp
+++ b/server/src/parameter_server.cpp
@@ -131,11 +131,25 @@ ParameterServer::ParameterServer(
         {
           param_update_ = true;
         }
+
+#if RCLCPP_VERSION_MAJOR < 17
+        // For ROS Humble (rclcpp 16.x) compatibility, handle save-on-update in on-set callback
+        // Post-set callbacks were added in Iron (rclcpp 17.x) and later
+        if(must_save_on_update_)
+        {
+          this->StoreYamlFile();
+        }
+#endif
       }
 
       return result;
     };
-  
+
+  // callback_handler_ needs to be alive to keep the callback functional
+  callback_handler_ = this->add_on_set_parameters_callback(param_change_callback);
+
+#if RCLCPP_VERSION_MAJOR >= 17
+  // Use post-set callback for Iron (rclcpp 17.x) and later distributions
   auto post_param_change_callback =
     [this](const std::vector<rclcpp::Parameter> & parameters)
     {
@@ -147,9 +161,8 @@ ParameterServer::ParameterServer(
         }
       }
     };
-  // callback_handler_ needs to be alive to keep the callback functional
-  callback_handler_ = this->add_on_set_parameters_callback(param_change_callback);
   post_set_callback_handler_ = this->add_post_set_parameters_callback(post_param_change_callback);
+#endif
 
   save_trigger_ = this->create_service<std_srvs::srv::Trigger>("~/save_params",
     [this]([[maybe_unused]] const std_srvs::srv::Trigger::Request::SharedPtr& req,
@@ -192,6 +205,11 @@ ParameterServer::~ParameterServer()
 {
   RCLCPP_DEBUG(this->get_logger(), "%s", __PRETTY_FUNCTION__);
   this->remove_on_set_parameters_callback(callback_handler_.get());
+#if RCLCPP_VERSION_MAJOR >= 17
+  if (post_set_callback_handler_) {
+    this->remove_post_set_parameters_callback(post_set_callback_handler_.get());
+  }
+#endif
   StoreYamlFile();
 }
 

--- a/server/src/parameter_server.cpp
+++ b/server/src/parameter_server.cpp
@@ -24,6 +24,7 @@
 #include "rcl_yaml_param_parser/parser.h"
 #include "rclcpp/parameter.hpp"
 #include "rclcpp/parameter_map.hpp"
+#include "rclcpp/version.h"
 
 #define ROS_PARAMETER_KEY     "ros__parameters"
 #define ROS_PARAMETER_DOT_KEY "ros__parameters."


### PR DESCRIPTION
Use conditional compilation based on rclcpp version to support both Humble (rclcpp 16.x) and later distributions (Iron 17.x+). The PostSetParametersCallback API was added in Iron, so for Humble the save-on-update functionality is handled in the OnSetParametersCallback instead, while later distributions use the proper post-set callback.

This fixes the build errors on Humble while maintaining optimal behavior on newer distributions.

Specifically, the error is the following and was introduced in #73:

    In file included from server/src/parameter_server.cpp:15:
    server/include/parameter_server.h:75:3: error: 'PostSetParametersCallbackHandle' does not name a
    type; did you mean 'OnSetParametersCallbackHandle'?
       75 |   PostSetParametersCallbackHandle::SharedPtr post_set_callback_handler_;
          |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~