### PR TITLE
Use portable function name macro

### DIFF
--- a/server/src/parameter_server.cpp
+++ b/server/src/parameter_server.cpp
@@ -31,6 +31,12 @@
 #define PERSISTENT_KEY        "persistent"
 #define PERSISTENT_DOT_KEY    "persistent."
 
+#if defined(_MSC_VER)
+#define PARAMETER_SERVER_FUNCTION __FUNCSIG__
+#else
+#define PARAMETER_SERVER_FUNCTION __PRETTY_FUNCTION__
+#endif
+
 /**
  * @brief Converts a double to string with proper floating-point representation.
  *
@@ -66,7 +72,8 @@ ParameterServer::ParameterServer(
   persistent_yaml_file_(persistent_yaml_file),
   node_name_(get_name())
 {
-  RCLCPP_DEBUG(this->get_logger(), "%s yaml:%s", __PRETTY_FUNCTION__, persistent_yaml_file_.c_str());
+  RCLCPP_DEBUG(
+    this->get_logger(), "%s yaml:%s", PARAMETER_SERVER_FUNCTION, persistent_yaml_file_.c_str());
 
   int storing_period = 0;
   // if automatically_declare_parameters_from_overrides is false, then the parameter_overrides will not be declared.
@@ -204,7 +211,7 @@ ParameterServer::ParameterServer(
 
 ParameterServer::~ParameterServer()
 {
-  RCLCPP_DEBUG(this->get_logger(), "%s", __PRETTY_FUNCTION__);
+  RCLCPP_DEBUG(this->get_logger(), "%s", PARAMETER_SERVER_FUNCTION);
   this->remove_on_set_parameters_callback(callback_handler_.get());
 #if RCLCPP_VERSION_MAJOR >= 17
   if (post_set_callback_handler_) {
@@ -239,7 +246,7 @@ void ParameterServer::CheckYamlFile() {
 }
 
 void ParameterServer::CheckYamlFile(const std::string& file) {
-  RCLCPP_DEBUG(this->get_logger(), "%s", __PRETTY_FUNCTION__);
+  RCLCPP_DEBUG(this->get_logger(), "%s", PARAMETER_SERVER_FUNCTION);
   YAML::Node parameter_config = YAML::LoadFile(file);
   // check format "YAML must be dictionary type and level 1 can only have one key"
   if ((parameter_config.size() == 1 && parameter_config.Type() != YAML::NodeType::Map) ||
@@ -287,7 +294,7 @@ void ParameterServer::CheckYamlFile(const std::string& file) {
 
 void ParameterServer::LoadYamlFile()
 {
-  RCLCPP_DEBUG(this->get_logger(), "%s", __PRETTY_FUNCTION__);
+  RCLCPP_DEBUG(this->get_logger(), "%s", PARAMETER_SERVER_FUNCTION);
   // check whether yaml file exist
   if (!boost::filesystem::exists(persistent_yaml_file_))
   {
@@ -568,7 +575,7 @@ void ParameterServer::SaveNode(YAML::Emitter& out, YAML::Node node, const std::s
 
 void ParameterServer::StoreYamlFile()
 {
-  RCLCPP_DEBUG(this->get_logger(), "%s", __PRETTY_FUNCTION__);
+  RCLCPP_DEBUG(this->get_logger(), "%s", PARAMETER_SERVER_FUNCTION);
 
   if (param_update_)
   {
@@ -776,7 +783,7 @@ void ParameterServer::StoreYamlFile()
 
 bool ParameterServer::CheckPersistentParam(const std::vector<rclcpp::Parameter> & parameters)
 {
-  RCLCPP_DEBUG(this->get_logger(), "%s", __PRETTY_FUNCTION__);
+  RCLCPP_DEBUG(this->get_logger(), "%s", PARAMETER_SERVER_FUNCTION);
   bool flag = false;
 
   for (auto& parameter : parameters) {


### PR DESCRIPTION
This is part of an effort to contribute RoboStack downstream patches back upstream.

Origin: patch/ros-rolling-persist-parameter-server.win.patch, authored by Daisuke Nishimatsu.

Best-guess rationale: __PRETTY_FUNCTION__ is a GNU/Clang extension and is not available with MSVC. Routing debug logging through a small macro keeps the existing function-name diagnostics on GNU/Clang and uses __FUNCSIG__ on MSVC.